### PR TITLE
Update Keyring to Version 23.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "23.0.1" %}
+{% set version = "23.2.1" %}
 
 package:
   name: keyring
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/keyring/keyring-{{ version }}.tar.gz
-  sha256: 045703609dd3fccfcdb27da201684278823b72af515aedec1a8515719a038cb8
+  sha256: 6334aee6073db2fb1f30892697b1730105b5e9a77ce7e61fca6b435225493efe
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,12 @@ requirements:
   host:
     - python
     - pip
+    - wheel
     - setuptools_scm >=3.4.1
     - setuptools >=42
     - toml
   run:
-    - python
+    - python >=3.6
     - pywin32-ctypes  # [win]
     - secretstorage >=3.2  # [linux]
     - importlib_metadata >=3.6
@@ -34,6 +35,7 @@ requirements:
 test:
   requires:
     - pip
+    - python <3.10
     - pytest >=4.6
     - pytest-runner
     - setuptools_scm >=1.15.0
@@ -59,6 +61,7 @@ about:
     the python keyring lib provides a easy way to access the system keyring
     service from python.  it can be used in any application that needs safe
     password storage.
+  dev_url: https://github.com/jaraco/keyring
   doc_url: https://pypi.org/project/keyring/
   doc_source_url: https://github.com/jaraco/keyring/blob/master/readme.rst
 


### PR DESCRIPTION

1. check the upstream
2. check the pinnings
3. check changelogs
4. additional research
5. verify dev_url
6. verify doc_url
7. added pip to the test section
8. verify the test section
9. additional tests

In order to test the `` package version `` the following command was used:
`` 
The test result was the following:
``

In additional the `` package was used for additional testing

`` 
The test result was the following:
``

Based on the research findings and on the test results we can conclude that it is safe to update `` to version ``
