### PR TITLE
keyring 23.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,7 @@ test:
     - keyring.util
   commands:
     - pip check
-    # skip tests on OS-X, the default keychain is not available in the
-    # build environment
+    # skip tests on OS-X, the default keychain is not available in the build environment
     - py.test -v tests  # [not osx]
     - keyring --help
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,17 +16,16 @@ build:
     - keyring = keyring.cli:main
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
   host:
     - python
     - pip
+    - setuptools >=56
     - setuptools_scm >=3.4.1
-    - setuptools >=42
     - toml
+    - wheel
   run:
     - python
-    - pywin32-ctypes  # [win]
+    - pywin32-ctypes !=0.1.0,!=0.1.1  # [win]
     - secretstorage >=3.2  # [linux]
     - importlib_metadata >=3.6
     - jeepney >=0.4.2  # [linux]
@@ -34,7 +33,7 @@ requirements:
 test:
   requires:
     - pip
-    - pytest >=4.6
+    - pytest >=6
     - pytest-runner
     - setuptools_scm >=1.15.0
   source_files:
@@ -53,14 +52,16 @@ test:
 about:
   home: https://github.com/jaraco/keyring
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Store and access your passwords safely
   description: |
-    the python keyring lib provides a easy way to access the system keyring
+    The python keyring lib provides a easy way to access the system keyring
     service from python.  it can be used in any application that needs safe
     password storage.
   doc_url: https://pypi.org/project/keyring/
   doc_source_url: https://github.com/jaraco/keyring/blob/master/readme.rst
+  dev_url: https://github.com/jaraco/keyring
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "23.0.1" %}
+{% set version = "23.4.0" %}
 
 package:
   name: keyring
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/keyring/keyring-{{ version }}.tar.gz
-  sha256: 045703609dd3fccfcdb27da201684278823b72af515aedec1a8515719a038cb8
+  sha256: 88f206024295e3c6fb16bb0a60fb4bb7ec1185629dc5a729f12aa7c236d01387
 
 build:
   number: 0


### PR DESCRIPTION
Update keyring to 23.4.0

Bug Tracker: new open issues https://github.com/jaraco/keyring/issues
Upstream license:  License file:  https://github.com/jaraco/keyring/blob/master/LICENSE
Upstream Changelog: https://github.com/jaraco/keyring/blob/main/CHANGES.rst
Upstream setup.cfg:  https://github.com/jaraco/keyring/blob/v23.4.0/setup.cfg
Upstream pyproject.toml:  https://github.com/jaraco/keyring/blob/v23.4.0/pyproject.toml

The package keyring is mentioned inside the packages:
jira |  keyrings.alt | orange3 | poetry | pyviz_comms | secretstorage | spyder | twine |

Actions:
1. Update dependencies
2. Add license_family, dev_url

Result:
- all-succeeded