### PR TITLE
keyring 23.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "23.4.0" %}
+{% set version = "23.13.1" %}
 
 package:
   name: keyring
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/keyring/keyring-{{ version }}.tar.gz
-  sha256: 88f206024295e3c6fb16bb0a60fb4bb7ec1185629dc5a729f12aa7c236d01387
+  sha256: ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 7ddf990..1c2eb5f 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "23.4.0" %}
+{% set version = "23.13.1" %}
 
 package:
   name: keyring
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/keyring/keyring-{{ version }}.tar.gz
-  sha256: 88f206024295e3c6fb16bb0a60fb4bb7ec1185629dc5a729f12aa7c236d01387
+  sha256: ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/jaraco/keyring/releases
[Diff between the latest and previous upstream releases](https://github.com/jaraco/keyring/compare/23.4.0...23.13.1)
Changelog: https://github.com/jaraco/keyring/blob/main/CHANGES.rst
Requirements:
 * setup.cfg:  https://github.com/jaraco/keyring/blob/v23.13.1/setup.cfg
 *  pyproject.toml:  https://github.com/jaraco/keyring/blob/v23.13.1/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 23.13.1
 * Release on PyPi:
    * version: 23.13.1
    * date: 2022-12-18T20:24:43
* [PyPi history](https://pypi.org/project/keyring/#history)
 * Popularity: 
    * 3 months downloads: 466742.0
    * All time:  2729883 downloads -  keyring  23.13.1  Store and access your passwords safely  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family MIT is present
16. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/keyring-feedstock/recipe/meta.yaml
Dependencies: ['wheel', 'python', 'setuptools_scm >=3.4.1', 'importlib_metadata >=3.6', 'pip', 'toml', 'setuptools >=56']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/keyring-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/keyring-feedstock/tree/23.13.1)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/keyring)
* [Diff between upstream and feature branch](https://github.com/conda-forge/keyring-feedstock/compare/main...AnacondaRecipes:23.13.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/keyring-feedstock/compare/master...AnacondaRecipes:23.13.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/keyring-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 23.13.1 git@github.com:AnacondaRecipes/keyring-feedstock.git
```
