### PR TITLE
keyring 25.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "24.3.1" %}
+{% set version = "25.6.0" %}
 
 package:
   name: keyring
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/keyring/keyring-{{ version }}.tar.gz
-  sha256: c3327b6ffafc0e8befbdb597cacdb4928ffe5c1212f7645f186e6d9957a898db
+  sha256: 0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - keyring = keyring.cli:main
@@ -19,27 +19,27 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - setuptools_scm
+    - setuptools >=61.2
     - toml
     - wheel
+    - setuptools-scm >=3.4.1
   run:
     - python
-    - pywin32-ctypes >=0.2.2  # [win]
-    - secretstorage >=3.2  # [linux]
-    - jeepney >=0.4.2  # [linux]
-    - importlib_metadata >=4.11.4  # [py<312]
+    - pywin32-ctypes >=0.2.0  # [win]
+    - secretstorage >=3.2     # [linux]
+    - jeepney >=0.4.2         # [linux]
     - jaraco.classes
     - importlib_resources  # [py<39]
+    - importlib-metadata >=4.11.4  # [py<312]
+    - jaraco.functools
+    - jaraco.context
   run_constrained:
     - shtab >= 1.1.0
 
 test:
   requires:
     - pip
-    - pytest >=6
-    - pytest-runner
-    - setuptools_scm >=1.15.0
+    - pytest >=6,!=8.1.*
   source_files:
       - tests/*
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8029](https://anaconda.atlassian.net/browse/PKG-8029)
- [Upstream repo](https://github.com/jaraco/keyring/tree/v25.6.0)
- release-diff: https://github.com/jaraco/keyring/compare/v24.3.1...v25.6.0
- requirements-tagged: https://github.com/jaraco/keyring/blob/v25.6.0/pyproject.toml


### Explanation of changes:

- Skip py<39
- Update dependencies in `host`, `run`, `test.requires`


[PKG-8029]: https://anaconda.atlassian.net/browse/PKG-8029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ